### PR TITLE
Update onBrokenLinks value in docusaurus.config.ts

### DIFF
--- a/src/docusaurus.config.ts
+++ b/src/docusaurus.config.ts
@@ -18,7 +18,7 @@ const config: Config = {
   organizationName: 'facebook', // Usually your GitHub org/user name.
   projectName: 'docusaurus', // Usually your repo name.
 
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set


### PR DESCRIPTION
This PR updates the onBrokenLinks value in docusaurus.config.ts from 'throw' to 'warn'. This change will result in broken links being logged as warnings instead of throwing errors.