### PR TITLE
Add workflow to update issue status on webmasters reply

### DIFF
--- a/.github/workflows/issue-reply-workflow.yml
+++ b/.github/workflows/issue-reply-workflow.yml
@@ -1,0 +1,35 @@
+name: Issue Reply Labeler
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  labelOnReply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Label issue on reply
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issueComment = context.payload.comment;
+            const issue = context.payload.issue;
+            const commenter = issueComment.user.login;
+            const orgMembers = await github.orgs.listMembers({
+              org: 'tgilabs',
+              team_slug: 'webmasters'
+            });
+
+            const isWebmaster = orgMembers.data.some(member => member.login === commenter);
+
+            if (isWebmaster) {
+              github.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['התקבל מענה']
+              });
+            }


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow that automatically labels issues with 'התקבל מענה' when a member of the webmasters team comments on an issue in the tgilabs/workway-bugs repository.

- **Adds a new workflow file**: A new file named `issue-reply-workflow.yml` is added to the `.github/workflows` directory. This workflow is triggered by issue comment events.
- **Automates issue labeling**: The workflow checks if the comment author is a member of the webmasters team. If so, it automatically adds the 'התקבל מענה' label to the issue. This is achieved using the `actions/github-script` action to interact with the GitHub API, checking team membership and updating issue labels accordingly.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tgilabs/workway-bugs?shareId=bb0172a5-3d7a-440c-8b68-1ef59feabe03).