### PR TITLE
Improve Workway personal portfolio functionality

### DIFF
--- a/blog/2024-07-05.md
+++ b/blog/2024-07-05.md
@@ -1,6 +1,6 @@
 ---
-slug: v1-4-1
-title: עדכון WorkWay V1.4.1
+slug: v1-4-0
+title: עדכון WorkWay V1.4.0
 authors: [thefourcraft]
 tags: [עדכונים]
 ---


### PR DESCRIPTION
This commit improves the functionality of the Workway personal portfolio feature. It limits each seller to one image in their ad and disables the gallery for images. Instead, each seller will have a personalized portfolio website where they can showcase their work with images, videos, links, and descriptions. The portfolio website will be accessible through the workway.co.il domain using the seller's username.